### PR TITLE
Workaround for Windows EX_OK import

### DIFF
--- a/pdfcomments/__main__.py
+++ b/pdfcomments/__main__.py
@@ -8,7 +8,11 @@ __version__ = "0.1"
 
 from argparse import Namespace
 from collections import defaultdict
-from os import extsep, EX_OK
+from os import extsep
+try:
+    from os import EX_OK
+except ImportError:
+    EX_OK = 0
 from pathlib import Path
 import re
 import sys

--- a/pdfcomments/__main__.py
+++ b/pdfcomments/__main__.py
@@ -9,10 +9,6 @@ __version__ = "0.1"
 from argparse import Namespace
 from collections import defaultdict
 from os import extsep
-try:
-    from os import EX_OK
-except ImportError:
-    EX_OK = 0
 from pathlib import Path
 import re
 import sys
@@ -20,6 +16,11 @@ from typing import DefaultDict, Iterator, List, Optional, TextIO
 
 from PyPDF2 import PdfFileReader
 from PyPDF2.pdf import PageObject
+
+try:
+    from os import EX_OK
+except ImportError:
+    EX_OK = 0
 
 # monkey-patching to fix
 # https://github.com/mstamy2/PyPDF2/issues/151


### PR DESCRIPTION
Closes #2 

The import error workaround here https://github.com/hoffmangroup/pdfcomments/issues/2#issuecomment-644316665 is the only change needed for me to run this in Windows 10.  I tested it locally.