### PR TITLE
fix: Pin PyPDF2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='pdfcomments',
       license='GPLv3',
       package_data={"pdfcomments": ["py.typed"]},
       packages=['pdfcomments'],
-      install_requires=['PyPDF2'],
+      install_requires=['PyPDF2==1.28.5'],
       python_requires='>=3.6',
       entry_points={
         'console_scripts': ['pdfcomments=pdfcomments.__main__:main'],


### PR DESCRIPTION
PyPDF2 v2.0.0, released mid-2022, is not backwards compatible with v1.x. E.g.,

```
[...]
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/private/tmp/pdfcomments/pdfcomments/__main__.py", line 29, in <module>
    PDF_DOC_ENCODING = list(generic._pdfDocEncoding)
AttributeError: module 'PyPDF2.generic' has no attribute '_pdfDocEncoding'
```

This pins PyPDF2 to the compatible, last-published v1.x. 

---

Testing in a fresh virtual environment:

```
(venv) si@macbook /p/t/pdfcomments (master)> pip3 install -e .
Obtaining file:///private/tmp/pdfcomments
  Preparing metadata (setup.py) ... done
Collecting PyPDF2==1.28.5
  Downloading PyPDF2-1.28.5-py3-none-any.whl (87 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 87.1/87.1 kB 969.2 kB/s eta 0:00:00
Installing collected packages: PyPDF2, pdfcomments
  Running setup.py develop for pdfcomments
Successfully installed PyPDF2-1.28.5 pdfcomments-0.1
(venv) si@macbook /p/t/pdfcomments (master)> pdfcomments Algorithms.pdf notes 
(venv) si@macbook /p/t/pdfcomments (master)> echo $status
0
(venv) si@macbook /p/t/pdfcomments (master)> head notes
Minor comments:

p36: Test
```

---

(PS: neat tool; thanks for building this!)